### PR TITLE
Operations over Binary random access lists

### DIFF
--- a/agda/BinaryRandomAccessList.agda
+++ b/agda/BinaryRandomAccessList.agda
@@ -3,9 +3,12 @@
 open import Data.Nat
 open import Data.Unit
 open import Data.Empty
-open import Data.Product
+open import Data.Product 
 open import Data.Maybe
-open import Data.Vec
+open import Data.Fin using (fromℕ<)
+open import Data.Vec hiding (head ; tail)
+open import Function
+open import Relation.Nullary
 
 open import Relation.Binary.PropositionalEquality hiding ([_])
 open import Relation.Binary.HeterogeneousEquality hiding ([_])
@@ -37,21 +40,68 @@ module BinaryRandomAccessList where
   open import Structure.Bin
   open import Container.LeafBinaryTree
 
-  RAL : Set → Set
-  RAL A = DBin Tree
+  RAL-g : Set → ℕ → Set
+  RAL-g A n = DBin-g Tree 
                Container.LeafBinaryTree.toVec Container.LeafBinaryTree.fromVec
-               Container.LeafBinaryTree.iso-to-from Container.LeafBinaryTree.iso-from-to A
+               Container.LeafBinaryTree.iso-to-from Container.LeafBinaryTree.iso-from-to A n
 
+  RAL : Set → Set
+  RAL A = RAL-g A 0
 
   -- TODO: implement all the operations on the datastructure:
   --   cf. "Numerical representation as higher-order nested datatypes", Fig. 3, p.13 for the interface
   --   cf. Okasaki, Sec. 9.2.1 and 10.1.2 for the implementation
 
+  -- Returns an empty structure
   empty : ∀ {A} → RAL A
-  empty = {!!}
+  empty = ϵ
 
+  private
+    -- Appends a new Tree in a structure of trees
+    consTree : ∀ {A n} → Tree A n → RAL-g A n → RAL-g A n
+    consTree l ϵ = ϵ [ l ]I
+    consTree l (t O) = t [ l ]I
+    consTree l (t [ l₁ ]I) = consTree (Node l l₁) t O
+
+    -- Removes (and returns) the first tree of the list of trees if not empty
+    unconsTree : ∀ {A n} → RAL-g A n → Maybe $ Tree A n × RAL-g A n
+    unconsTree ϵ = nothing
+    unconsTree (e O) with unconsTree e
+    ... | just (Node t t₁ , ts) = just (t , ts [ t₁ ]I)
+    ... | nothing = nothing
+    unconsTree (e [ t ]I) = just (t , e O)
+
+    -- Retrieves an element in a list of trees
+    lookup-trees : ∀ {A n} → RAL-g A n → ℕ → Maybe A
+    lookup-trees ϵ _ = nothing
+    lookup-trees (r O) = lookup-trees r
+    lookup-trees (_[_]I {k} s r) i = let pow = 2 ^ k in
+      case i <? pow of λ {
+        (yes p) → just $ lookup-tree r $ fromℕ< p ;
+        (no _) → lookup-trees s (i ∸ pow)}
+
+    -- Replaces an element inside the structure
+    update-trees : ∀ {A n} → RAL-g A n → ℕ → A → RAL-g A n
+    update-trees ϵ _ _ = ϵ
+    update-trees (r O) i a = update-trees r i a O
+    update-trees (_[_]I {k} r t) i a = let pow = 2 ^ k in
+      case i <? pow of λ {
+        (yes p) → r [ update-tree (fromℕ< p) a t ]I ;
+        (no _) → (update-trees r (i ∸ pow)) a [ t ]I  }
+
+  -- Appends an element at the beginning of the structure
   cons : ∀ {A} → A → RAL A → RAL A
-  cons = {!!}
+  cons = consTree ∘ Leaf
+
+  -- Returns the first element in the structure
+  head : ∀ {A} → RAL A → Maybe A
+  head r with unconsTree r
+  ... | just (Leaf x , _) = just x
+  ... | nothing = nothing
+
+  -- Returns the smaller structure without its first element
+  tail : ∀ {A} → RAL A → Maybe $ RAL A
+  tail = Data.Maybe.map proj₂ ∘ unconsTree
 
   front : ∀ {A} → RAL A → A × RAL A
   front = {!!}
@@ -63,7 +113,7 @@ module BinaryRandomAccessList where
   rear = {!!}
 
   access : ∀ {A} → RAL A → ℕ → Maybe A
-  access = {!!}
+  access = lookup-trees
 
   update : ∀ {A} → RAL A → ℕ → A → RAL A
-  update = {!!}
+  update = update-trees

--- a/agda/Container/LeafBinaryTree.agda
+++ b/agda/Container/LeafBinaryTree.agda
@@ -3,6 +3,8 @@
 open import Data.Nat
 open import Data.Vec
 open import Data.Product
+open import Data.Fin using (Fin)
+open import Function
 
 open import Relation.Binary.PropositionalEquality hiding ([_])
 open import Relation.Binary.HeterogeneousEquality hiding ([_])
@@ -22,6 +24,15 @@ module Container.LeafBinaryTree where
   fromVec (suc k) vs with splitAt (2 ^ k) vs
   ... | (ls , rs , _ ) with splitAt (2 ^ k) rs
   ... | (rs , _ , _) = Node (fromVec k ls) (fromVec k rs)
+
+  -- To be improved, we are working with binary trees after all
+  -- It is sad to transform to vectors to lookup, but it's late
+  -- and I don't want to handle decidability cases with 2^k-1
+  lookup-tree : ∀ {A k} → Tree A k → Fin (2 ^ k) → A
+  lookup-tree = lookup ∘ toVec
+
+  update-tree : ∀ {A k} → Fin (2 ^ k) → A → Tree A k → Tree A k
+  update-tree i a = fromVec _ ∘ (updateAt i (const a)) ∘ toVec
 
   iso-to-from : ∀ {A k} (t : Tree A k) → fromVec k (toVec t) ≡ t
   iso-to-from = {!TO BE DONE!}

--- a/agda/Numerical/Bin.agda
+++ b/agda/Numerical/Bin.agda
@@ -5,15 +5,24 @@ open import Data.Nat
 
 module Numerical.Bin where
 
-  data Bin : Set where
-    ϵ  : Bin
-    _O : Bin → Bin
-    _I : Bin → Bin
+data Bin : Set where
+  ϵ  : Bin
+  _O : Bin → Bin
+  _I : Bin → Bin
 
-  Bin⇒Nat-g : Bin → ℕ → ℕ
-  Bin⇒Nat-g ϵ k = 0
-  Bin⇒Nat-g (bs O) k = {- 0 * 2 ^ k + -} Bin⇒Nat-g bs (1 + k)
-  Bin⇒Nat-g (bs I) k = {- 1 * -} 2 ^ k + Bin⇒Nat-g bs (1 + k)
+incr : Bin → Bin
+incr ϵ = ϵ I
+incr (b O) = b I
+incr (b I) = incr b O
 
-  Bin⇒Nat : Bin → ℕ
-  Bin⇒Nat b = Bin⇒Nat-g b 0
+Bin⇒ℕ-g : Bin → ℕ → ℕ
+Bin⇒ℕ-g ϵ k = 0
+Bin⇒ℕ-g (bs O) k = {- 0 * 2 ^ k + -} Bin⇒ℕ-g bs (suc k)
+Bin⇒ℕ-g (bs I) k = {- 1 * -} 2 ^ k + Bin⇒ℕ-g bs (suc k)
+
+Bin⇒ℕ : Bin → ℕ
+Bin⇒ℕ b = Bin⇒ℕ-g b 0
+
+ℕ⇒Bin : ℕ → Bin
+ℕ⇒Bin zero = ϵ
+ℕ⇒Bin (suc n) = incr (ℕ⇒Bin n)

--- a/agda/Structure/Bin.agda
+++ b/agda/Structure/Bin.agda
@@ -31,8 +31,8 @@ module Structure.Bin
 
   data DBin-g (A : Set) : ℕ → Set where
     ϵ : ∀ {n} → DBin-g A n
-    _O : ∀ {n} → (bs : DBin-g A (suc n)) → DBin-g A n
-    _[_]I : ∀{n} → (bs : DBin-g A (suc n))(t : T A n) → DBin-g A n
+    _O : ∀ {n} (bs : DBin-g A (suc n)) → DBin-g A n
+    _[_]I : ∀ {n} (bs : DBin-g A (suc n)) (t : T A n) → DBin-g A n
 
   DBin : Set → Set
   DBin A = DBin-g A 0
@@ -44,27 +44,29 @@ module Structure.Bin
   forget (bs O) = (forget bs) O
   forget (bs [ t ]I) = (forget bs) I
 
-  toVec-g : ∀ {A k} (t : DBin-g A k) → Vec A  (Bin⇒Nat-g (forget t) k)
+  toVec-g : ∀ {A k} (t : DBin-g A k) → Vec A (Bin⇒ℕ-g (forget t) k)
   toVec-g ϵ = []
   toVec-g (bs O)  = toVec-g bs
   toVec-g (bs [ t ]I) = T-toVec t ++ toVec-g bs
 
-  toVec : ∀ {A} (t : DBin A) → Vec A (Bin⇒Nat (forget t))
+  toVec : ∀ {A} (t : DBin A) → Vec A (Bin⇒ℕ (forget t))
   toVec t = toVec-g t
 
-  fromVec-g : ∀ {A k} b (vs : Vec A (Bin⇒Nat-g b k)) → DBin-g A k
+  fromVec-g : ∀ {A k} b (vs : Vec A (Bin⇒ℕ-g b k)) → DBin-g A k
   fromVec-g ϵ [] = ϵ
   fromVec-g (b O) vs = fromVec-g b vs O
   fromVec-g {k = k} (b I) vs with splitAt (2 ^ k) vs
   ... | (t , vs , _) = fromVec-g b vs [ T-fromVec k t ]I
 
-  fromVec : ∀ {A} b (vs : Vec A (Bin⇒Nat b)) → DBin A
+  fromVec : ∀ {A} b (vs : Vec A (Bin⇒ℕ b)) → DBin A
   fromVec b vs = fromVec-g b vs
 
   -- We expect the following:
 
   iso-to-from : ∀ {A} (t : DBin A) → fromVec (forget t) (toVec t) ≡ t
-  iso-to-from = {!TO BE DONE!}
+  iso-to-from ϵ = refl
+  iso-to-from (t O) = {!iso-to-from t!}
+  iso-to-from (t [ t₁ ]I) = {!!}
 
-  iso-from-to : ∀ {A} b (vs : Vec A (Bin⇒Nat b)) → toVec (fromVec b vs) ≅ vs -- heterogeneous equality!
+  iso-from-to : ∀ {A} b (vs : Vec A (Bin⇒ℕ b)) → toVec (fromVec b vs) ≅ vs -- heterogeneous equality!
   iso-from-to = {!TO BE DONE!}


### PR DESCRIPTION
This PR proposes an implementations for the primitives on binary random access lists.
It includes the following changes:
- addition of `lookup` and `update` for trees
- addition of an indexed version of bral to allow for recursive functions over the structure
- implementation of the actual primitives
A question: what is the semantics of the remaining primitives, namely `snoc`, `rear` and `front`. My guess:
- `snoc` adds a tree of size k+1 at the end of the structure
- `rear` returns the last tree of the structure
- `front` returns the first tree of the structure